### PR TITLE
Remove `ip_addr`

### DIFF
--- a/psh.proto
+++ b/psh.proto
@@ -15,14 +15,10 @@ message PshResponse {
 
 message HostInfoRequest {
   string token = 1;
-  oneof ip_addr {
-    fixed32 ipv4 = 2;
-    bytes ipv6 = 3;
-  }
-  optional string os = 4;
-  optional string architecture = 5;
-  optional string hostname = 6;
-  optional string kernel_version = 7;
+  optional string os = 2;
+  optional string architecture = 3;
+  optional string hostname = 4;
+  optional string kernel_version = 5;
 }
 
 message HostInfoResponse {


### PR DESCRIPTION
It is possible to get the IP address from the gRPC connection, and it is not safe to trust the psh client with what the IP address they said they are.