### PR TITLE
Fix `wasm_args` def

### DIFF
--- a/psh.proto
+++ b/psh.proto
@@ -50,7 +50,7 @@ message HostInfoResponse {
 
 message Task {
   bytes wasm = 1;
-  optional repeated string wasm_args = 2;
+  repeated string wasm_args = 2;
   // Number of non-leap-milliseconds since Jan 1, 1970 UTC.
   optional uint64 end_time = 3;
 }


### PR DESCRIPTION
A repeated field is inherently optional, `optional repeated` will failed to compile.