### PR TITLE
Remove `key_type` map

### DIFF
--- a/psh.proto
+++ b/psh.proto
@@ -76,8 +76,6 @@ message Metadata {
 message MetricMeta {
   uint64 start_time = 1;
   uint64 end_time = 2;
-  // Mapping from keys to types
-  map<string, string> key_type = 3;
 }
 
 message DataResponse {


### PR DESCRIPTION
We will leverage influxdb line protocol to store type metadata for our keys, so explicit types in RPC message is unnecessary.